### PR TITLE
Enjoy 2pb

### DIFF
--- a/src/main/java/com/nef/notenoughfakepixel/config/features/Fishing.java
+++ b/src/main/java/com/nef/notenoughfakepixel/config/features/Fishing.java
@@ -1,15 +1,41 @@
 package com.nef.notenoughfakepixel.config.features;
 
 import com.google.gson.annotations.Expose;
+import com.nef.notenoughfakepixel.config.gui.core.config.annotations.ConfigAccordionId;
+import com.nef.notenoughfakepixel.config.gui.core.config.annotations.ConfigEditorAccordion;
 import com.nef.notenoughfakepixel.config.gui.core.config.annotations.ConfigEditorBoolean;
 import com.nef.notenoughfakepixel.config.gui.core.config.annotations.ConfigOption;
 
 public class Fishing {
 
     @Expose
-    @ConfigOption(name = "Fishing Countdown", desc = "Notify when a fish is ready to be caught.")
+    @ConfigOption(name = "Fishing Alert", desc = "Settings for the fishing bite alert.")
+    @ConfigEditorAccordion(id = 0)
+    public boolean fishingAlertAccordion = false;
+
+    @Expose
+    @ConfigOption(name = "Enable Alert", desc = "Activate the fishing alert feature.")
     @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
     public boolean fishingCountdown = true;
+
+    @Expose
+    @ConfigOption(name = "Enable Incoming Message", desc = "Show INCOMING when a fish is approaching the bobber.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean fishingIncomingMessage = true;
+
+    @Expose
+    @ConfigOption(name = "Enable Bite ETA", desc = "Show a countdown until the fish bites.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean fishingBiteEta = true;
+
+    @Expose
+    @ConfigOption(name = "Enable Slug Mode", desc = "Suppresses all alerts for 20s after the bobber enters lava, matching the Slug fish catch requirement.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 0)
+    public boolean fishingSlugMode = false;
 
     @Expose
     @ConfigOption(name = "Notify Legendary Creatures", desc = "Notify when a legendary creature is caught.")

--- a/src/main/java/com/nef/notenoughfakepixel/config/features/Mining.java
+++ b/src/main/java/com/nef/notenoughfakepixel/config/features/Mining.java
@@ -194,6 +194,18 @@ public class Mining {
     public int crystalHeatLevel = 80;
 
     @Expose
+    @ConfigOption(name = "Chest Tracker", desc = "Highlights nearby chests and draws a trail to them.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 2)
+    public boolean chestTracker = true;
+
+    @Expose
+    @ConfigOption(name = "Chest Tracker Clear Key", desc = "Keybind to clear all tracked chests.")
+    @ConfigEditorKeybind(defaultKey = Keyboard.KEY_NONE)
+    @ConfigAccordionId(id = 2)
+    public int chestTrackerClearKey = Keyboard.KEY_NONE;
+
+    @Expose
     @ConfigOption(name = "Crystal Hollows Map Settings", desc = "Settings for the Crystal Hollows map.")
     @ConfigAccordionId(id = 2)
     @ConfigEditorAccordion(id = 2_1)

--- a/src/main/java/com/nef/notenoughfakepixel/config/features/Slayer.java
+++ b/src/main/java/com/nef/notenoughfakepixel/config/features/Slayer.java
@@ -162,14 +162,40 @@ public class Slayer {
     @ConfigEditorDropdown(values = {"Auto Open", "Semi Auto", "Disabled"})
     public int slayerMaddoxCalling = 1;
 
+    // Inferno Demonlord Subcategory
     @Expose
-    @ConfigOption(name = "Display Blaze Pillar Title", desc = "Display title when blaze pillar is nearby.")
+    @ConfigOption(name = "Inferno Demonlord", desc = "Settings for the Inferno Demonlord boss fight.")
+    @ConfigEditorAccordion(id = 4)
+    public boolean infernoDemonlordAccordion = false;
+
+    @Expose
+    @ConfigOption(name = "Display Blaze Pillar Title", desc = "Display title when a blaze pillar is nearby.")
     @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4)
     public boolean slayerFirePillarDisplay = true;
 
     @Expose
-    @ConfigOption(name = "Blaze Attunements Display", desc = "Display blaze attunements.")
+    @ConfigOption(name = "Show Attunements Overlay", desc = "Settings for attunement outline and highlight.")
+    @ConfigEditorAccordion(id = 4_1)
+    @ConfigAccordionId(id = 4)
+    public boolean blazeAttunementAccordion = false;
+
+    @Expose
+    @ConfigOption(name = "Show Outline", desc = "Draw a coloured outline around attunement minions.")
     @ConfigEditorBoolean
-    public boolean slayerBlazeAttunements = true;
+    @ConfigAccordionId(id = 4_1)
+    public boolean slayerBlazeAttunementOutline = true;
+
+    @Expose
+    @ConfigOption(name = "Show Full Attunement", desc = "Fill the attunement minion model with its attunement colour.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4_1)
+    public boolean slayerBlazeAttunementFill = false;
+
+    @Expose
+    @ConfigOption(name = "Filter Hellion Shield Spam", desc = "Hide the 'Hellion Shield' and 'Strike using attunement' messages when hitting with the wrong attunement.")
+    @ConfigEditorBoolean
+    @ConfigAccordionId(id = 4)
+    public boolean slayerHellionShieldFilter = true;
 
 }

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingAlert.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingAlert.java
@@ -27,7 +27,7 @@ import net.minecraftforge.fml.common.gameevent.TickEvent;
 import java.util.*;
 
 @RegisterEvents
-public class FishingCountdown {
+public class FishingAlert {
 
     private final Minecraft mc = Minecraft.getMinecraft();
 

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingCountdown.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingCountdown.java
@@ -9,216 +9,400 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.projectile.EntityFishHook;
+import net.minecraft.init.Blocks;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
 import net.minecraft.network.play.server.S2APacketParticles;
+import net.minecraft.util.BlockPos;
 import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.MathHelper;
-import net.minecraft.util.Vec3;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
+import net.minecraftforge.event.entity.EntityJoinWorldEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @RegisterEvents
 public class FishingCountdown {
+
     private final Minecraft mc = Minecraft.getMinecraft();
-    private EntityFishHook playerBobber;
-    private long fishBiteTime;
-    private String countdownText = null;
-    private long countdownEndTime = 0;
-    private final List<ParticleData> particleHistory = new ArrayList<>();
-    private static final int MIN_PARTICLES_FOR_PATH = 3;
-    private static final long MAX_PARTICLE_AGE = 1000;
-    private static final double MAX_INTER_PARTICLE_DISTANCE = 1.0;
-    private boolean biteTriggered = false;
 
-    private static class ParticleData {
-        Vec3 position;
-        long timestamp;
+    private final HashMap<Integer, EntityFishHook> hookEntities = new HashMap<>();
+    private final HashMap<WakeChain, List<Integer>> chains = new HashMap<>();
 
-        ParticleData(Vec3 position, long timestamp) {
-            this.position = position;
-            this.timestamp = timestamp;
+    private long lastCastRodMillis = 0;
+    private int pingDelayTicks = 0;
+    private final List<Integer> pingDelayList = new ArrayList<>();
+    private int buildupSoundDelay = 0;
+    private int hookedStateTicks = 0;
+    private int tickCounter = 0;
+
+    // Used to deduplicate the double-fire from MixinNetHandlerPlayClient
+    private S2APacketParticles lastProcessedPacket = null;
+
+    // Absolute timestamp (ms) when the wake chain is predicted to reach the bobber
+    private long countdownEtaMs = 0;
+
+    // Slug mode: timestamp when the bobber first entered lava (0 = not in lava)
+    private long slugLavaEntryMs = 0;
+    private static final long SLUG_DELAY_MS = 20_000;
+
+    public enum WarningState { NOTHING, INCOMING, HOOKED }
+    private WarningState warningState = WarningState.NOTHING;
+
+    private static class WakeChain {
+        int particleNum = 0;
+        long lastUpdate;
+        double currentAngle;
+        final HashMap<Integer, Double> distances = new HashMap<>();
+
+        WakeChain(long lastUpdate, double angle) {
+            this.lastUpdate = lastUpdate;
+            this.currentAngle = angle;
         }
     }
+
+    // ── Entity tracking ──────────────────────────────────────────────────────
 
     @SubscribeEvent
-    public void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.phase != TickEvent.Phase.END || mc.theWorld == null || mc.thePlayer == null) return;
-        if (!Config.feature.fishing.fishingCountdown) return;
+    public void onEntityJoin(EntityJoinWorldEvent event) {
+        if (!event.world.isRemote) return;
+        Entity e = event.entity;
+        if (!(e instanceof EntityFishHook)) return;
 
-        updatePlayerBobber();
-        mc.addScheduledTask(() -> {
-            checkFishBiteStatus();
-        });
-        mc.addScheduledTask(() -> {
-            cleanupParticleHistory();
-        });
-    }
+        EntityFishHook hook = (EntityFishHook) e;
+        hookEntities.put(hook.getEntityId(), hook);
 
-    private void updatePlayerBobber() {
-        playerBobber = mc.thePlayer.fishEntity;
-    }
-
-    private void checkFishBiteStatus() {
-        if (mc.thePlayer == null) return;
-
-        if (playerBobber == null) {
-            countdownText = null;
-            particleHistory.clear();
-            biteTriggered = false;
-            return;
-        }
-
-        if (!biteTriggered && System.currentTimeMillis() >= fishBiteTime && countdownText != null) {
-            countdownText = "§c§l!!!";
-            SoundUtils.playSound(
-                    mc.thePlayer.getPosition().getX(),
-                    mc.thePlayer.getPosition().getY(),
-                    mc.thePlayer.getPosition().getZ(),
-                    "note.pling",
-                    1.0f,
-                    1.0f
-            );
-            countdownEndTime = System.currentTimeMillis() + 2000;
-            biteTriggered = true; // prevent spam
-        }
-
-        if (biteTriggered && System.currentTimeMillis() > countdownEndTime) {
-            countdownText = null;
-            biteTriggered = false;
-        }
-    }
-
-    @SubscribeEvent
-    public void onParticlePacketReceived(ParticlePacketEvent event) {
-        S2APacketParticles packet = event.getPacket();
-        if (playerBobber == null) return;
-
-        EnumParticleTypes[] fishingParticles = {
-                EnumParticleTypes.WATER_WAKE,
-                EnumParticleTypes.LAVA
-        };
-
-        for (EnumParticleTypes particleType : fishingParticles) {
-            if (particleType == packet.getParticleType()) {
-                Vec3 particlePos = new Vec3(
-                        packet.getXCoordinate(),
-                        packet.getYCoordinate(),
-                        packet.getZCoordinate()
-                );
-                processFishingParticle(particlePos);
-                break;
+        if (hook.angler == mc.thePlayer) {
+            long now = System.currentTimeMillis();
+            long delay = now - lastCastRodMillis;
+            if (delay > 0 && delay < 500) {
+                pingDelayList.add(0, (int) Math.min(delay, 300));
             }
         }
     }
 
-    private void processFishingParticle(Vec3 particlePos) {
-        if (playerBobber == null) return;
+    @SubscribeEvent
+    public void onPlayerInteract(PlayerInteractEvent event) {
+        if (event.action != PlayerInteractEvent.Action.RIGHT_CLICK_AIR) return;
+        if (event.entityPlayer != mc.thePlayer) return;
+        ItemStack held = event.entityPlayer.getHeldItem();
+        if (held == null || held.getItem() != Items.fishing_rod) return;
+        long now = System.currentTimeMillis();
+        if (now - lastCastRodMillis > 500) lastCastRodMillis = now;
+    }
 
-        double dx = particlePos.xCoord - playerBobber.posX;
-        double dz = particlePos.zCoord - playerBobber.posZ;
-        double horizontalDist = Math.sqrt(dx * dx + dz * dz);
+    // ── Tick: warning state + cleanup ────────────────────────────────────────
 
-        if (horizontalDist > 3) return;
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || mc.thePlayer == null) return;
+        if (!Config.feature.fishing.fishingCountdown) return;
 
-        long currentTime = System.currentTimeMillis();
-        particleHistory.add(new ParticleData(particlePos, currentTime));
+        if (buildupSoundDelay > 0) buildupSoundDelay--;
 
-        List<ParticleData> snapshot = new ArrayList<>(particleHistory);
+        if (mc.thePlayer.fishEntity == null) {
+            countdownEtaMs = 0;
+            slugLavaEntryMs = 0;
+        }
 
-        if (snapshot.size() >= MIN_PARTICLES_FOR_PATH) {
-            if (isValidParticlePath(new Vec3(playerBobber.posX, 0, playerBobber.posZ), snapshot)) {
-                ParticleData firstParticle = snapshot.get(0);
-                ParticleData lastParticle = snapshot.get(snapshot.size() - 1);
+        // Slug mode: track whether the bobber is sitting in lava
+        if (Config.feature.fishing.fishingSlugMode && mc.thePlayer.fishEntity != null && mc.theWorld != null) {
+            BlockPos bobberPos = new BlockPos(
+                    mc.thePlayer.fishEntity.posX,
+                    mc.thePlayer.fishEntity.posY,
+                    mc.thePlayer.fishEntity.posZ);
+            net.minecraft.block.Block block = mc.theWorld.getBlockState(bobberPos).getBlock();
+            boolean inLava = block == Blocks.lava || block == Blocks.flowing_lava;
+            if (inLava) {
+                if (slugLavaEntryMs == 0) slugLavaEntryMs = System.currentTimeMillis();
+            } else {
+                slugLavaEntryMs = 0;
+            }
+        }
 
-                double firstDistance = new Vec3(firstParticle.position.xCoord, 0, firstParticle.position.zCoord)
-                        .distanceTo(new Vec3(playerBobber.posX, 0, playerBobber.posZ));
-                double lastDistance = new Vec3(lastParticle.position.xCoord, 0, lastParticle.position.zCoord)
-                        .distanceTo(new Vec3(playerBobber.posX, 0, playerBobber.posZ));
-                long totalTimeDiff = lastParticle.timestamp - firstParticle.timestamp;
+        // Refine ping estimate while bobber is out
+        if (mc.thePlayer.fishEntity != null && !pingDelayList.isEmpty()) {
+            while (pingDelayList.size() > 5) pingDelayList.remove(pingDelayList.size() - 1);
+            int total = 0;
+            for (int d : pingDelayList) total += d;
+            pingDelayTicks = (int) Math.floor((total / (double) pingDelayList.size()) / 50.0);
+        }
 
-                if (totalTimeDiff > 0 && firstDistance > lastDistance) {
-                    double distanceDecrease = firstDistance - lastDistance;
-                    double speed = distanceDecrease / totalTimeDiff; // blocks per ms
-
-                    if (speed > 0) {
-                        double currentDistance = lastDistance;
-                        double timeToReach = currentDistance / speed; // ms
-                        fishBiteTime = currentTime + (long) timeToReach;
-
-                        if (timeToReach > 100) {
-                            double countdownVal = MathHelper.clamp_double(timeToReach / 1000.0, 0.1, 5.0);
-                            countdownText = "§e§l" + formatCountdownNumber(countdownVal);
-                            countdownEndTime = currentTime + 1000;
-                        }
+        // Advance warning state
+        if (hookedStateTicks > 0) {
+            hookedStateTicks--;
+            warningState = WarningState.HOOKED;
+        } else {
+            warningState = WarningState.NOTHING;
+            if (mc.thePlayer.fishEntity != null) {
+                int myId = mc.thePlayer.fishEntity.getEntityId();
+                for (Map.Entry<WakeChain, List<Integer>> entry : chains.entrySet()) {
+                    if (entry.getKey().particleNum >= 3 && entry.getValue().contains(myId)) {
+                        warningState = WarningState.INCOMING;
+                        break;
                     }
                 }
             }
         }
-    }
 
-    private boolean isValidParticlePath(Vec3 bobberPos, List<ParticleData> history) {
-        if (bobberPos == null) return false;
-        if (history.size() < MIN_PARTICLES_FOR_PATH) return false;
-
-        for (int i = 1; i < history.size(); i++) {
-            if (history.get(i) == null || history.get(i).position == null ||
-                    history.get(i - 1) == null || history.get(i - 1).position == null) {
-                return false;
-            }
-            double interParticleDistance = history.get(i).position.distanceTo(history.get(i - 1).position);
-            if (interParticleDistance > MAX_INTER_PARTICLE_DISTANCE) {
-                return false;
-            }
+        // Cleanup dead hooks and stale chains every second
+        if (tickCounter++ >= 20) {
+            tickCounter = 0;
+            long now = System.currentTimeMillis();
+            hookEntities.entrySet().removeIf(e -> e.getValue().isDead);
+            chains.entrySet().removeIf(entry ->
+                now - entry.getKey().lastUpdate > 200 ||
+                entry.getValue().isEmpty() ||
+                Collections.disjoint(entry.getValue(), hookEntities.keySet())
+            );
         }
-
-        if (history.get(0) == null || history.get(0).position == null ||
-                history.get(history.size() - 1) == null || history.get(history.size() - 1).position == null) {
-            return false;
-        }
-
-        double firstDistance = history.get(0).position.distanceTo(bobberPos);
-        double lastDistance = history.get(history.size() - 1).position.distanceTo(bobberPos);
-
-        return lastDistance < firstDistance;
     }
 
-    private void cleanupParticleHistory() {
-        long currentTime = System.currentTimeMillis();
-        particleHistory.removeIf(particle -> currentTime - particle.timestamp > MAX_PARTICLE_AGE);
-    }
-
-    private String formatCountdownNumber(double value) {
-        return String.format("%.1f", Math.round(value * 10) / 10.0);
-    }
+    // ── Particle detection ───────────────────────────────────────────────────
 
     @SubscribeEvent
-    @SideOnly(Side.CLIENT)
+    public void onParticlePacket(ParticlePacketEvent event) {
+        if (!Config.feature.fishing.fishingCountdown) return;
+        if (!SkyblockData.getCurrentGamemode().isSkyblock()) return;
+        if (hookEntities.isEmpty()) return;
+
+        S2APacketParticles p = event.getPacket();
+        // MixinNetHandlerPlayClient posts the event twice — skip the duplicate
+        if (p == lastProcessedPacket) return;
+        lastProcessedPacket = p;
+
+        EnumParticleTypes type = p.getParticleType();
+        if (type != EnumParticleTypes.WATER_WAKE
+                && type != EnumParticleTypes.SMOKE_NORMAL
+                && type != EnumParticleTypes.FLAME) return;
+        if (Math.abs(p.getYOffset() - 0.01f) > 0.001f) return;
+
+        double x = p.getXCoordinate(), y = p.getYCoordinate(), z = p.getZCoordinate();
+        double xOff = p.getXOffset(), zOff = p.getZOffset();
+
+        double angle1 = calcAngle(xOff, -zOff);
+        double angle2 = calcAngle(-xOff, zOff);
+
+        List<Integer> possible1 = new ArrayList<>();
+        List<Integer> possible2 = new ArrayList<>();
+
+        for (EntityFishHook hook : hookEntities.values()) {
+            if (hook.isDead) continue;
+            HookResult ret = classifyHook(hook, x, y, z, angle1, angle2);
+            switch (ret) {
+                case ANGLE1: possible1.add(hook.getEntityId()); break;
+                case ANGLE2: possible2.add(hook.getEntityId()); break;
+                case EITHER:
+                    possible1.add(hook.getEntityId());
+                    possible2.add(hook.getEntityId());
+                    break;
+                default: break;
+            }
+        }
+
+        if (possible1.isEmpty() && possible2.isEmpty()) return;
+
+        long now = System.currentTimeMillis();
+        boolean foundChain = false;
+
+        for (Map.Entry<WakeChain, List<Integer>> entry : chains.entrySet()) {
+            WakeChain chain = entry.getKey();
+            if (now - chain.lastUpdate > 200) continue;
+
+            List<Integer> possible;
+            double updateAngle;
+            if (angleWithinRange(chain.currentAngle, angle1, 16)) {
+                possible = possible1; updateAngle = angle1;
+            } else if (angleWithinRange(chain.currentAngle, angle2, 16)) {
+                possible = possible2; updateAngle = angle2;
+            } else continue;
+
+            if (Collections.disjoint(entry.getValue(), possible)) continue;
+
+            Set<Integer> kept = new HashSet<>();
+            for (int hookId : possible) {
+                if (!entry.getValue().contains(hookId) || !chain.distances.containsKey(hookId)) continue;
+                EntityFishHook hook = hookEntities.get(hookId);
+                if (hook == null || hook.isDead) continue;
+
+                double oldDist = chain.distances.get(hookId);
+                double dx = hook.posX - x, dz = hook.posZ - z;
+                double newDist = Math.sqrt(dx * dx + dz * dz);
+                double delta = oldDist - newDist;
+
+                if (newDist >= 0.2 && (delta <= -0.1 || delta >= 0.3)) continue;
+
+                // Sound + state for the player's own hook
+                if (mc.thePlayer.fishEntity != null
+                        && mc.thePlayer.fishEntity.getEntityId() == hookId
+                        && chain.particleNum > 3) {
+                    float lavaOff = (type == EnumParticleTypes.SMOKE_NORMAL) ? 0.03f : 0.1f;
+                    if (newDist <= 0.2f + lavaOff * pingDelayTicks) {
+                        if (hookedStateTicks <= 0 && !isSlugWaiting()) {
+                            SoundUtils.playGlobalSound("note.pling", 1.0f, 2.0f);
+                        }
+                        hookedStateTicks = 12;
+                    } else if (newDist >= 0.4f + 0.1f * pingDelayTicks && buildupSoundDelay <= 0 && !isSlugWaiting()) {
+                        SoundUtils.playGlobalSound("note.pling", 0.5f, calcPitch((float) newDist - (0.3f + 0.1f * pingDelayTicks)));
+                        buildupSoundDelay = 4;
+                    }
+                }
+
+                // Countdown ETA: speed = distDecrease / timeSinceLastParticle
+                if (mc.thePlayer.fishEntity != null && mc.thePlayer.fishEntity.getEntityId() == hookId) {
+                    long timeDiff = now - chain.lastUpdate;
+                    double distDecrease = oldDist - newDist;
+                    if (timeDiff > 0 && distDecrease > 0) {
+                        double speedBlocksPerMs = distDecrease / timeDiff;
+                        countdownEtaMs = now + (long) (newDist / speedBlocksPerMs);
+                    }
+                }
+
+                chain.distances.put(hookId, newDist);
+                kept.add(hookId);
+            }
+
+            if (kept.isEmpty()) continue;
+
+            entry.getValue().retainAll(kept);
+            chain.distances.keySet().retainAll(kept);
+            chain.lastUpdate = now;
+            chain.particleNum++;
+            chain.currentAngle = updateAngle;
+            foundChain = true;
+        }
+
+        if (!foundChain) {
+            possible1.removeAll(possible2);
+            List<Integer> toUse = !possible1.isEmpty() ? possible1 : possible2;
+            double useAngle = !possible1.isEmpty() ? angle1 : angle2;
+            if (toUse.isEmpty()) return;
+
+            WakeChain chain = new WakeChain(now, useAngle);
+            for (int hookId : toUse) {
+                EntityFishHook hook = hookEntities.get(hookId);
+                if (hook == null || hook.isDead) continue;
+                double dx = hook.posX - x, dz = hook.posZ - z;
+                chain.distances.put(hookId, Math.sqrt(dx * dx + dz * dz));
+            }
+            chains.put(chain, toUse);
+        }
+    }
+
+    // ── Rendering ────────────────────────────────────────────────────────────
+
+    @SubscribeEvent
     public void onRenderOverlay(RenderGameOverlayEvent.Post event) {
+        if (event.type != RenderGameOverlayEvent.ElementType.TEXT) return;
         if (!SkyblockData.getCurrentGamemode().isSkyblock()) return;
         if (!Config.feature.fishing.fishingCountdown) return;
-        if (event.type != RenderGameOverlayEvent.ElementType.TEXT || countdownText == null) return;
-        if (System.currentTimeMillis() > countdownEndTime) {
-            countdownText = null;
-            return;
+        if (warningState == WarningState.NOTHING) return;
+        if (isSlugWaiting()) return;
+
+        String text;
+        if (warningState == WarningState.HOOKED) {
+            text = "§c§l!!!";
+        } else {
+            // INCOMING state: ETA takes priority if enabled and valid, else fall back to text
+            long remaining = countdownEtaMs - System.currentTimeMillis();
+            boolean etaValid = remaining > 100 && remaining < 10_000;
+            if (Config.feature.fishing.fishingBiteEta && etaValid) {
+                text = "§e§l" + String.format("%.1f", remaining / 1000.0) + "s";
+            } else if (Config.feature.fishing.fishingIncomingMessage) {
+                text = "§e§lINCOMING";
+            } else {
+                return; // neither sub-option is enabled, nothing to show
+            }
         }
 
         FontRenderer fr = mc.fontRendererObj;
         ScaledResolution res = new ScaledResolution(mc);
-
         GlStateManager.pushMatrix();
         GlStateManager.scale(2.0, 2.0, 2.0);
-
-        int textWidth = fr.getStringWidth(countdownText);
-        int x = (res.getScaledWidth() / 4) - (textWidth / 2);
+        int x = (res.getScaledWidth() / 4) - (fr.getStringWidth(text) / 2);
         int y = (res.getScaledHeight() / 4) + 10;
-
-        fr.drawStringWithShadow(countdownText, x, y, 0xFFFFFF);
+        fr.drawStringWithShadow(text, x, y, 0xFFFFFF);
         GlStateManager.popMatrix();
+    }
+
+    // ── World unload ─────────────────────────────────────────────────────────
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        hookEntities.clear();
+        chains.clear();
+        warningState = WarningState.NOTHING;
+        hookedStateTicks = 0;
+        countdownEtaMs = 0;
+        slugLavaEntryMs = 0;
+        lastProcessedPacket = null;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private boolean isSlugWaiting() {
+        return Config.feature.fishing.fishingSlugMode
+                && slugLavaEntryMs > 0
+                && System.currentTimeMillis() - slugLavaEntryMs < SLUG_DELAY_MS;
+    }
+
+    private double calcAngle(double xOff, double zOff) {
+        double aX = Math.toDegrees(Math.acos(xOff / 0.04));
+        double aZ = Math.toDegrees(Math.asin(zOff / 0.04));
+        if (xOff < 0) aZ = 180 - aZ;
+        if (zOff < 0) aX = 360 - aX;
+        aX = ((aX % 360) + 360) % 360;
+        aZ = ((aZ % 360) + 360) % 360;
+        double d = aX - aZ;
+        if (d < -180) d += 360;
+        if (d > 180) d -= 360;
+        return aZ + d / 2.0;
+    }
+
+    private boolean angleWithinRange(double a, double b, double range) {
+        double d = Math.abs(a - b);
+        if (d > 180) d = 360 - d;
+        return d <= range;
+    }
+
+    private enum HookResult { NOT_POSSIBLE, EITHER, ANGLE1, ANGLE2 }
+
+    private HookResult classifyHook(EntityFishHook hook, double px, double py, double pz, double a1, double a2) {
+        double dY = py - hook.posY;
+        double tolerance = 0.5;
+        if (mc.theWorld != null) {
+            for (int i = -2; i < 2; i++) {
+                net.minecraft.block.Block b = mc.theWorld.getBlockState(new BlockPos(px, py + i, pz)).getBlock();
+                if (b == Blocks.flowing_lava || b == Blocks.flowing_water || b == Blocks.lava) {
+                    tolerance = 2.0;
+                    break;
+                }
+            }
+        }
+        if (Math.abs(dY) > tolerance) return HookResult.NOT_POSSIBLE;
+
+        double dX = px - hook.posX, dZ = pz - hook.posZ;
+        double dist = Math.sqrt(dX * dX + dZ * dZ);
+        if (dist < 0.2) return HookResult.EITHER;
+
+        float allowance = (float) Math.toDegrees(Math.atan2(0.03125, dist)) * 1.5f;
+        float hookAngle = (float) Math.toDegrees(Math.atan2(dX, dZ));
+        hookAngle = ((hookAngle % 360) + 360) % 360;
+
+        if (angleWithinRange(a1, hookAngle, allowance)) return HookResult.ANGLE1;
+        if (angleWithinRange(a2, hookAngle, allowance)) return HookResult.ANGLE2;
+        return HookResult.NOT_POSSIBLE;
+    }
+
+    private static final float ZERO_PITCH = 1.0f, MAX_PITCH = 0.1f, MAX_DIST = 5f;
+
+    private float calcPitch(float d) {
+        d = Math.max(0.1f, Math.min(d, MAX_DIST));
+        return 1f / (d + (1f / (ZERO_PITCH - MAX_PITCH))) * (1f - d / MAX_DIST) + MAX_PITCH;
     }
 }

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingCountdown.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/FishingCountdown.java
@@ -51,6 +51,13 @@ public class FishingCountdown {
     private long slugLavaEntryMs = 0;
     private static final long SLUG_DELAY_MS = 20_000;
 
+    // Splash confirmation: non-zero while waiting for a bite splash near the bobber
+    private long awaitingSplashUntilMs = 0;
+    private long splashConfirmedMs = 0;
+    private boolean biteAlertFired = false;
+    private static final long SPLASH_WINDOW_MS = 500;
+    private static final long BITE_ALERT_DELAY_MS = 50;
+
     public enum WarningState { NOTHING, INCOMING, HOOKED }
     private WarningState warningState = WarningState.NOTHING;
 
@@ -133,11 +140,19 @@ public class FishingCountdown {
             pingDelayTicks = (int) Math.floor((total / (double) pingDelayList.size()) / 50.0);
         }
 
+        // Fire bite alert after splash confirmation delay
+        if (splashConfirmedMs > 0 && !biteAlertFired && System.currentTimeMillis() >= splashConfirmedMs && !isSlugWaiting()) {
+            SoundUtils.playGlobalSound("note.pling", 1.0f, 2.0f);
+            biteAlertFired = true;
+            splashConfirmedMs = 0;
+        }
+
         // Advance warning state
         if (hookedStateTicks > 0) {
             hookedStateTicks--;
             warningState = WarningState.HOOKED;
         } else {
+            awaitingSplashUntilMs = 0;
             warningState = WarningState.NOTHING;
             if (mc.thePlayer.fishEntity != null) {
                 int myId = mc.thePlayer.fishEntity.getEntityId();
@@ -177,6 +192,24 @@ public class FishingCountdown {
         lastProcessedPacket = p;
 
         EnumParticleTypes type = p.getParticleType();
+
+        // Splash confirmation: after the approach condition fires, wait for a bite splash near our bobber.
+        // Water bite: WATER_BUBBLE. Lava bite: LAVA only (FLAME is also an approach particle and fires too early).
+        if (awaitingSplashUntilMs > 0 && !biteAlertFired
+                && (type == EnumParticleTypes.WATER_BUBBLE || type == EnumParticleTypes.LAVA)
+                && mc.thePlayer != null && mc.thePlayer.fishEntity != null) {
+            if (System.currentTimeMillis() <= awaitingSplashUntilMs) {
+                double dx = p.getXCoordinate() - mc.thePlayer.fishEntity.posX;
+                double dy = p.getYCoordinate() - mc.thePlayer.fishEntity.posY;
+                double dz = p.getZCoordinate() - mc.thePlayer.fishEntity.posZ;
+                if (dx * dx + dy * dy + dz * dz <= 1.0) {
+                    splashConfirmedMs = System.currentTimeMillis() + BITE_ALERT_DELAY_MS;
+                    awaitingSplashUntilMs = 0;
+                }
+            } else {
+                awaitingSplashUntilMs = 0;
+            }
+        }
         if (type != EnumParticleTypes.WATER_WAKE
                 && type != EnumParticleTypes.SMOKE_NORMAL
                 && type != EnumParticleTypes.FLAME) return;
@@ -244,7 +277,8 @@ public class FishingCountdown {
                     float lavaOff = (type == EnumParticleTypes.SMOKE_NORMAL) ? 0.03f : 0.1f;
                     if (newDist <= 0.2f + lavaOff * pingDelayTicks) {
                         if (hookedStateTicks <= 0 && !isSlugWaiting()) {
-                            SoundUtils.playGlobalSound("note.pling", 1.0f, 2.0f);
+                            awaitingSplashUntilMs = now + SPLASH_WINDOW_MS;
+                            biteAlertFired = false;
                         }
                         hookedStateTicks = 12;
                     } else if (newDist >= 0.4f + 0.1f * pingDelayTicks && buildupSoundDelay <= 0 && !isSlugWaiting()) {
@@ -306,6 +340,7 @@ public class FishingCountdown {
 
         String text;
         if (warningState == WarningState.HOOKED) {
+            if (!biteAlertFired) return;
             text = "§c§l!!!";
         } else {
             // INCOMING state: ETA takes priority if enabled and valid, else fall back to text
@@ -340,6 +375,9 @@ public class FishingCountdown {
         hookedStateTicks = 0;
         countdownEtaMs = 0;
         slugLavaEntryMs = 0;
+        awaitingSplashUntilMs = 0;
+        splashConfirmedMs = 0;
+        biteAlertFired = false;
         lastProcessedPacket = null;
     }
 

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/GreatCatchNotifier.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/fishing/GreatCatchNotifier.java
@@ -16,6 +16,7 @@ public class GreatCatchNotifier {
     @SubscribeEvent
     public void onChat(@NotNull ClientChatReceivedEvent e) {
         if (!Config.feature.fishing.fishingLegendaryCreatures) return;
+        if (e.type != 1) return;
 
         String message = e.message.getUnformattedText();
         String title = null;

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/ChestTracker.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/ChestTracker.java
@@ -1,0 +1,176 @@
+package com.nef.notenoughfakepixel.features.skyblock.mining.crystalhollows;
+
+import com.nef.notenoughfakepixel.config.gui.Config;
+import com.nef.notenoughfakepixel.config.gui.core.config.KeybindHelper;
+import com.nef.notenoughfakepixel.env.registers.RegisterEvents;
+import com.nef.notenoughfakepixel.events.PacketReadEvent;
+import com.nef.notenoughfakepixel.serverdata.SkyblockData;
+import net.minecraft.block.BlockChest;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import net.minecraft.network.play.server.S23PacketBlockChange;
+import net.minecraft.util.BlockPos;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.event.world.WorldEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import org.lwjgl.opengl.GL11;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterEvents
+public class ChestTracker {
+
+    private final Minecraft mc = Minecraft.getMinecraft();
+    private final List<TrackedChest> chests = new ArrayList<>();
+    private static final int DETECT_RADIUS = 10;
+
+    @SubscribeEvent
+    public void onPacketRead(PacketReadEvent event) {
+        if (!Config.feature.mining.chestTracker) return;
+        if (!SkyblockData.getCurrentLocation().isCrystalHollows()) return;
+
+        if (event.packet instanceof S23PacketBlockChange) {
+            S23PacketBlockChange p = (S23PacketBlockChange) event.packet;
+            if (p.blockState != null && p.blockState.getBlock() instanceof BlockChest)
+                trackChest(p.getBlockPosition());
+        } else if (event.packet instanceof S22PacketMultiBlockChange) {
+            S22PacketMultiBlockChange p = (S22PacketMultiBlockChange) event.packet;
+            for (S22PacketMultiBlockChange.BlockUpdateData upd : p.getChangedBlocks()) {
+                if (upd.getBlockState().getBlock() instanceof BlockChest)
+                    trackChest(upd.getPos());
+            }
+        }
+    }
+
+    private void trackChest(BlockPos pos) {
+        if (mc.thePlayer == null) return;
+        double dx = pos.getX() + 0.5 - mc.thePlayer.posX;
+        double dy = pos.getY() + 0.5 - mc.thePlayer.posY;
+        double dz = pos.getZ() + 0.5 - mc.thePlayer.posZ;
+        if (Math.sqrt(dx * dx + dy * dy + dz * dz) > DETECT_RADIUS) return;
+        for (TrackedChest existing : chests) {
+            if (existing.pos.equals(pos)) return;
+        }
+        chests.add(new TrackedChest(pos));
+    }
+
+    @SubscribeEvent
+    public void onClientTick(TickEvent.ClientTickEvent event) {
+        if (event.phase != TickEvent.Phase.END || mc.thePlayer == null) return;
+        if (!Config.feature.mining.chestTracker) return;
+
+        if (!SkyblockData.getCurrentLocation().isCrystalHollows()
+                || KeybindHelper.isKeyDown(Config.feature.mining.chestTrackerClearKey)) {
+            chests.clear();
+            return;
+        }
+
+        if (mc.theWorld == null) return;
+        List<TrackedChest> toRemove = new ArrayList<>();
+        for (TrackedChest chest : chests) {
+            if (!mc.theWorld.isBlockLoaded(chest.pos)) continue;
+            if (!(mc.theWorld.getBlockState(chest.pos).getBlock() instanceof BlockChest))
+                toRemove.add(chest);
+        }
+        chests.removeAll(toRemove);
+    }
+
+    @SubscribeEvent
+    public void onRenderWorld(RenderWorldLastEvent event) {
+        if (!Config.feature.mining.chestTracker) return;
+        if (!SkyblockData.getCurrentLocation().isCrystalHollows()) return;
+        if (chests.isEmpty()) return;
+        if (mc.thePlayer == null) return;
+
+        double px = mc.getRenderManager().viewerPosX;
+        double py = mc.getRenderManager().viewerPosY;
+        double pz = mc.getRenderManager().viewerPosZ;
+
+        GlStateManager.pushMatrix();
+        GlStateManager.disableDepth();
+        GlStateManager.disableTexture2D();
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.disableLighting();
+
+        Tessellator tess = Tessellator.getInstance();
+        WorldRenderer wr = tess.getWorldRenderer();
+
+        boolean drawing = false;
+        try {
+            wr.begin(GL11.GL_LINES, DefaultVertexFormats.POSITION_COLOR);
+            drawing = true;
+
+            // Line from player to first chest
+            TrackedChest first = chests.get(0);
+            float[] fc = getColor(first.getLifeRatio());
+            double fx = first.pos.getX() + 0.5 - px;
+            double fy = first.pos.getY() + 0.5 - py;
+            double fz = first.pos.getZ() + 0.5 - pz;
+            wr.pos(0, 0, 0).color(fc[0], fc[1], 0f, 1f).endVertex();
+            wr.pos(fx, fy, fz).color(fc[0], fc[1], 0f, 1f).endVertex();
+
+            // Chain lines between chests
+            for (int i = 0; i < chests.size() - 1; i++) {
+                TrackedChest a = chests.get(i);
+                TrackedChest b = chests.get(i + 1);
+                float[] ca = getColor(a.getLifeRatio());
+                float[] cb = getColor(b.getLifeRatio());
+                double ax = a.pos.getX() + 0.5 - px, ay = a.pos.getY() + 0.5 - py, az = a.pos.getZ() + 0.5 - pz;
+                double bx = b.pos.getX() + 0.5 - px, by = b.pos.getY() + 0.5 - py, bz = b.pos.getZ() + 0.5 - pz;
+                wr.pos(ax, ay, az).color(ca[0], ca[1], 0f, 1f).endVertex();
+                wr.pos(bx, by, bz).color(cb[0], cb[1], 0f, 1f).endVertex();
+            }
+
+            // Wireframe box around each chest
+            for (TrackedChest chest : chests) {
+                float[] c = getColor(chest.getLifeRatio());
+                double x = chest.pos.getX() - px, y = chest.pos.getY() - py, z = chest.pos.getZ() - pz;
+                double x2 = x + 1, y2 = y + 1, z2 = z + 1;
+                float r = c[0], g = c[1];
+
+                wr.pos(x,  y,  z ).color(r,g,0f,1f).endVertex(); wr.pos(x2, y,  z ).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y,  z ).color(r,g,0f,1f).endVertex(); wr.pos(x2, y,  z2).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y,  z2).color(r,g,0f,1f).endVertex(); wr.pos(x,  y,  z2).color(r,g,0f,1f).endVertex();
+                wr.pos(x,  y,  z2).color(r,g,0f,1f).endVertex(); wr.pos(x,  y,  z ).color(r,g,0f,1f).endVertex();
+
+                wr.pos(x,  y2, z ).color(r,g,0f,1f).endVertex(); wr.pos(x2, y2, z ).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y2, z ).color(r,g,0f,1f).endVertex(); wr.pos(x2, y2, z2).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y2, z2).color(r,g,0f,1f).endVertex(); wr.pos(x,  y2, z2).color(r,g,0f,1f).endVertex();
+                wr.pos(x,  y2, z2).color(r,g,0f,1f).endVertex(); wr.pos(x,  y2, z ).color(r,g,0f,1f).endVertex();
+
+                wr.pos(x,  y,  z ).color(r,g,0f,1f).endVertex(); wr.pos(x,  y2, z ).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y,  z ).color(r,g,0f,1f).endVertex(); wr.pos(x2, y2, z ).color(r,g,0f,1f).endVertex();
+                wr.pos(x2, y,  z2).color(r,g,0f,1f).endVertex(); wr.pos(x2, y2, z2).color(r,g,0f,1f).endVertex();
+                wr.pos(x,  y,  z2).color(r,g,0f,1f).endVertex(); wr.pos(x,  y2, z2).color(r,g,0f,1f).endVertex();
+            }
+
+            tess.draw();
+            drawing = false;
+        } finally {
+            if (drawing) {
+                try { tess.draw(); } catch (Exception ignored) {}
+            }
+            GlStateManager.enableDepth();
+            GlStateManager.enableTexture2D();
+            GlStateManager.disableBlend();
+            GlStateManager.enableLighting();
+            GlStateManager.popMatrix();
+        }
+    }
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        chests.clear();
+    }
+
+    private float[] getColor(float lifeRatio) {
+        return new float[]{ 1.0f - lifeRatio, lifeRatio };
+    }
+}

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/TrackedChest.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/TrackedChest.java
@@ -1,0 +1,19 @@
+package com.nef.notenoughfakepixel.features.skyblock.mining.crystalhollows;
+
+import net.minecraft.util.BlockPos;
+
+public class TrackedChest {
+
+    public final BlockPos pos;
+    public final long spawnTime;
+
+    public TrackedChest(BlockPos pos) {
+        this.pos = pos;
+        this.spawnTime = System.currentTimeMillis();
+    }
+
+    public float getLifeRatio() {
+        long elapsed = System.currentTimeMillis() - spawnTime;
+        return Math.max(0.0f, 1.0f - (elapsed / 30000.0f));
+    }
+}

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/CrystalHollowsTreasureModule.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/CrystalHollowsTreasureModule.java
@@ -2,64 +2,189 @@ package com.nef.notenoughfakepixel.features.skyblock.mining.crystalhollows.treas
 
 import com.nef.notenoughfakepixel.config.gui.Config;
 import com.nef.notenoughfakepixel.env.registers.RegisterEvents;
+import com.nef.notenoughfakepixel.events.PacketReadEvent;
 import com.nef.notenoughfakepixel.serverdata.SkyblockData;
 import com.nef.notenoughfakepixel.utils.ColorUtils;
 import com.nef.notenoughfakepixel.utils.Logger;
 import com.nef.notenoughfakepixel.utils.RenderUtils;
 import com.nef.notenoughfakepixel.variables.Area;
 import com.nef.notenoughfakepixel.variables.Location;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockChest;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.init.Blocks;
+import net.minecraft.network.play.server.S22PacketMultiBlockChange;
+import net.minecraft.network.play.server.S23PacketBlockChange;
 import net.minecraft.util.BlockPos;
+import net.minecraft.util.Vec3;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.awt.*;
+import java.util.List;
 
 @RegisterEvents
 public class CrystalHollowsTreasureModule {
 
-    private static final TreasureTriangulator TRI = TreasureTriangulator.getInstance();
+    private static final GradientSolver GRAD_SOLVER = new GradientSolver();
+    private static final double         LERP        = 0.15;
+
+    private double lastSeenDist = -1.0;
+    private int    postResetSkip = 0;
+
+    private BlockPos confirmedChest = null;
+
+    private double smoothX0 = Double.NaN, smoothZ0 = Double.NaN;
+    private double smoothX1 = Double.NaN, smoothZ1 = Double.NaN;
+
+    @SubscribeEvent
+    public void onPacketRead(PacketReadEvent event) {
+        if (!Config.feature.mining.crystalMetalDetector) return;
+        if (SkyblockData.getCurrentArea() != Area.CH_MINES_OF_DIVAN) return;
+
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.thePlayer == null || mc.theWorld == null) return;
+
+        // detect if our confirmed chest was covered by a gold block
+        if (confirmedChest != null) {
+            boolean covered = false;
+            if (event.packet instanceof S23PacketBlockChange) {
+                S23PacketBlockChange p = (S23PacketBlockChange) event.packet;
+                if (p.getBlockPosition().equals(confirmedChest)
+                        && mc.theWorld.getBlockState(confirmedChest).getBlock() instanceof BlockChest
+                        && !(p.blockState != null && p.blockState.getBlock() instanceof BlockChest)) {
+                    covered = true;
+                }
+            } else if (event.packet instanceof S22PacketMultiBlockChange) {
+                S22PacketMultiBlockChange p = (S22PacketMultiBlockChange) event.packet;
+                for (S22PacketMultiBlockChange.BlockUpdateData upd : p.getChangedBlocks()) {
+                    if (upd.getPos().equals(confirmedChest)
+                            && mc.theWorld.getBlockState(confirmedChest).getBlock() instanceof BlockChest
+                            && !(upd.getBlockState().getBlock() instanceof BlockChest)) {
+                        covered = true;
+                        break;
+                    }
+                }
+            }
+            if (covered) {
+                Logger.log("§c[MD] Confirmed chest was covered — resetting");
+                confirmedChest = null;
+                resetAll();
+                return;
+            }
+        }
+
+        // detect a new chest spawning from a gold block nearby
+        BlockPos newChest = null;
+        if (event.packet instanceof S23PacketBlockChange) {
+            S23PacketBlockChange p = (S23PacketBlockChange) event.packet;
+            if (p.blockState != null && p.blockState.getBlock() instanceof BlockChest)
+                newChest = p.getBlockPosition();
+        } else if (event.packet instanceof S22PacketMultiBlockChange) {
+            S22PacketMultiBlockChange p = (S22PacketMultiBlockChange) event.packet;
+            for (S22PacketMultiBlockChange.BlockUpdateData upd : p.getChangedBlocks()) {
+                if (upd.getBlockState().getBlock() instanceof BlockChest) {
+                    newChest = upd.getPos();
+                    break;
+                }
+            }
+        }
+        if (newChest == null) return;
+
+        Block oldBlock = mc.theWorld.getBlockState(newChest).getBlock();
+        if (oldBlock != Blocks.gold_block && oldBlock != Blocks.air) return;
+
+        double px = mc.thePlayer.posX, py = mc.thePlayer.posY, pz = mc.thePlayer.posZ;
+        double cx = newChest.getX() + 0.5, cy = newChest.getY() + 0.5, cz = newChest.getZ() + 0.5;
+        double distToPlayer = Math.sqrt((cx-px)*(cx-px) + (cy-py)*(cy-py) + (cz-pz)*(cz-pz));
+        if (distToPlayer > 5) return;
+
+        confirmedChest = newChest;
+        resetSmooth();
+        Logger.log("§a[MD] Chest confirmed at " + newChest.getX() + "," + newChest.getY() + "," + newChest.getZ()
+            + " §a(dist=" + String.format("%.1f", distToPlayer) + ")");
+    }
 
     @SubscribeEvent
     public void onChatReceived(net.minecraftforge.client.event.ClientChatReceivedEvent e) {
+        String msg = e.message.getFormattedText();
+
+        if (msg.contains("with your Metal Detector!")) {
+            resetAll();
+            confirmedChest = null;
+            lastSeenDist = -1.0;
+        }
+
         if (!Config.feature.mining.crystalMetalDetector) return;
         if (SkyblockData.getCurrentArea() != Area.CH_MINES_OF_DIVAN) return;
-        String msg = e.message.getFormattedText();
-        if (msg.contains("TREASURE: ")) {
-            try {
-                String distanceStr = msg.split("TREASURE: ")[1].split("m")[0].replaceAll("[^0-9.]", "");
-                double distance = Double.parseDouble(distanceStr);
-                EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
-                TRI.handleData(p.posX, p.posY, p.posZ, distance);
-            } catch (Exception ex) {
-                Logger.log("§cMetal Detector: parse parser failed");
+        if (!msg.contains("TREASURE: ")) return;
+
+        if (postResetSkip > 0) {
+            postResetSkip--;
+            Logger.log("§7[MD] Skipping stale post-chest reading (" + postResetSkip + " remaining)");
+            return;
+        }
+
+        try {
+            String distStr = msg.split("TREASURE: ")[1].split("m")[0].replaceAll("[^0-9.]", "");
+            double distance = Double.parseDouble(distStr);
+            EntityPlayerSP p = Minecraft.getMinecraft().thePlayer;
+
+            boolean changed = Math.abs(distance - lastSeenDist) >= 0.05;
+            if (!changed) return;
+            lastSeenDist = distance;
+
+            if (confirmedChest != null) {
+                double dx = confirmedChest.getX() + 0.5 - p.posX;
+                double dy = confirmedChest.getY() + 0.5 - p.posY;
+                double dz = confirmedChest.getZ() + 0.5 - p.posZ;
+                double actualDist = Math.sqrt(dx*dx + dy*dy + dz*dz);
+                if (Math.abs(actualDist - distance) > 3.0) {
+                    Logger.log("§c[MD] Chest mismatch (chest=" + String.format("%.1f", actualDist)
+                        + "m, MD=" + String.format("%.1f", distance) + "m) — resetting");
+                    confirmedChest = null;
+                    resetAll();
+                }
             }
+
+            boolean gradAccepted = GRAD_SOLVER.addReading(p.posX, p.posY, p.posZ, distance);
+            if (gradAccepted) {
+                Logger.log("§b[MD] grad_cands=§f" + GRAD_SOLVER.getCandidateCount()
+                    + " §b| grad_readings=§f" + GRAD_SOLVER.getReadingCount());
+            }
+
+        } catch (Exception ex) {
+            Logger.log("§c[MD] parse error: " + ex.getMessage());
         }
     }
 
     @SubscribeEvent
     public void onWorldUnload(WorldEvent.Unload e) {
-        if (!Config.feature.mining.crystalMetalDetector) return;
-        TRI.reset();
+        resetAll();
+        confirmedChest = null;
+        lastSeenDist = -1.0;
     }
 
     @SubscribeEvent
     public void onWorldLoad(WorldEvent.Load e) {
-        if (!Config.feature.mining.crystalMetalDetector) return;
-        if (SkyblockData.getCurrentLocation().equals(Location.CRYSTAL_HOLLOWS)) TRI.reset();
+        if (SkyblockData.getCurrentLocation().equals(Location.CRYSTAL_HOLLOWS)) {
+            resetAll();
+            confirmedChest = null;
+        }
     }
 
     @SubscribeEvent
     public void onRightClick(PlayerInteractEvent e) {
         if (!Config.feature.mining.crystalMetalDetector) return;
         if (!SkyblockData.getCurrentLocation().equals(Location.CRYSTAL_HOLLOWS)) return;
-        if (e.action.equals(PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) &&
+        if (e.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK &&
                 e.world.getBlockState(e.pos).getBlock() instanceof BlockChest) {
-            TRI.reset();
+            resetAll();
+            confirmedChest = null;
+            postResetSkip = 7;
         }
     }
 
@@ -70,14 +195,73 @@ public class CrystalHollowsTreasureModule {
         Minecraft mc = Minecraft.getMinecraft();
         if (mc.thePlayer == null || mc.theWorld == null) return;
 
-        GridTrilateration.Int3 guess = TRI.getBestGuess();
+        Color waypointColor = ColorUtils.getColor(Config.feature.mining.crystalDivanWaypointColor);
+        int playerY = (int) mc.thePlayer.posY;
 
-        if (guess != null) {
-            EntityPlayerSP p = mc.thePlayer;
-            Color waypointColor = ColorUtils.getColor(Config.feature.mining.crystalDivanWaypointColor);
-            RenderUtils.renderBeaconBeam(new BlockPos(guess.x, p.posY, guess.z), waypointColor.getRGB(), 1, event.partialTicks);
-            RenderUtils.renderWaypointText("Guess", new BlockPos(guess.x, p.posY + 3, guess.z), event.partialTicks);
+        if (confirmedChest != null) {
+            int beamY = findFloorY(confirmedChest.getX(), confirmedChest.getZ(), confirmedChest.getY());
+            BlockPos beamPos = new BlockPos(confirmedChest.getX(), beamY, confirmedChest.getZ());
+            BlockPos textPos = new BlockPos(confirmedChest.getX(), playerY, confirmedChest.getZ());
+            RenderUtils.renderBeaconBeam(beamPos, waypointColor.getRGB(), 1, event.partialTicks);
+            RenderUtils.renderWaypointText("TREASURE!", textPos.add(0, 3, 0), event.partialTicks);
+            RenderUtils.draw3DLine(
+                mc.thePlayer.getPositionEyes(event.partialTicks),
+                new Vec3(confirmedChest.getX() + 0.5, confirmedChest.getY() + 0.5, confirmedChest.getZ() + 0.5),
+                waypointColor, 2, true, event.partialTicks
+            );
+            return;
+        }
+
+        List<BlockPos> gradCands = GRAD_SOLVER.getCandidatePositions();
+        if (!gradCands.isEmpty()) {
+            BlockPos c0 = gradCands.get(0);
+            double tx0 = c0.getX() + 0.5, tz0 = c0.getZ() + 0.5;
+            if (Double.isNaN(smoothX0)) { smoothX0 = tx0; smoothZ0 = tz0; }
+            else { smoothX0 += (tx0 - smoothX0) * LERP; smoothZ0 += (tz0 - smoothZ0) * LERP; }
+            drawCandidate(smoothX0, playerY, smoothZ0,
+                gradCands.size() == 1 ? "Treasure?" : "Guess A", waypointColor, event.partialTicks);
+            if (gradCands.size() >= 2) {
+                BlockPos c1 = gradCands.get(1);
+                double tx1 = c1.getX() + 0.5, tz1 = c1.getZ() + 0.5;
+                if (Double.isNaN(smoothX1)) { smoothX1 = tx1; smoothZ1 = tz1; }
+                else { smoothX1 += (tx1 - smoothX1) * LERP; smoothZ1 += (tz1 - smoothZ1) * LERP; }
+                drawCandidate(smoothX1, playerY, smoothZ1, "Guess B", waypointColor, event.partialTicks);
+            } else {
+                smoothX1 = smoothZ1 = Double.NaN;
+            }
         }
     }
 
+    private void drawCandidate(double x, int playerY, double z, String label, Color color, float partialTicks) {
+        int bx = (int) Math.floor(x), bz = (int) Math.floor(z);
+        int beamY = findFloorY(bx, bz, playerY);
+        RenderUtils.renderBeaconBeam(new BlockPos(bx, beamY, bz), color.getRGB(), 1, partialTicks);
+        RenderUtils.renderWaypointText(label, new BlockPos(bx, playerY, bz).add(0, 3, 0), partialTicks);
+    }
+
+    private int findFloorY(int x, int z, int fromY) {
+        Minecraft mc = Minecraft.getMinecraft();
+        if (mc.theWorld == null) return Math.max(1, fromY - 20);
+        int limit = Math.max(1, fromY - 50);
+        for (int y = fromY; y >= limit; y--) {
+            try {
+                if (mc.theWorld.getBlockState(new BlockPos(x, y, z)).getBlock() != Blocks.air) {
+                    return y + 1;
+                }
+            } catch (Exception ignored) {
+                return Math.max(1, fromY - 20);
+            }
+        }
+        return limit;
+    }
+
+    private void resetAll() {
+        GRAD_SOLVER.reset();
+        postResetSkip = 0;
+        resetSmooth();
+    }
+
+    private void resetSmooth() {
+        smoothX0 = smoothZ0 = smoothX1 = smoothZ1 = Double.NaN;
+    }
 }

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/GradientSolver.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/GradientSolver.java
@@ -1,0 +1,306 @@
+package com.nef.notenoughfakepixel.features.skyblock.mining.crystalhollows.treasure;
+
+import net.minecraft.util.BlockPos;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Primary:    gradient — places 2 initial candidates from the first pair.
+ * Complement: sphere-projection refinement — iteratively pulls each candidate
+ *             onto every reading's XZ circle, fixing gradient approximation error.
+ * Validation: once narrowed to 1 candidate, each new reading checks whether
+ *             the measured gradient (Δd/|ΔP|) agrees with the direction toward
+ *             that candidate.  Three consecutive disagreements invalidate it and
+ *             trigger fresh regeneration.
+ * Stability:  once the solver has ever narrowed to 1 candidate, regeneration
+ *             always picks the closest new candidate to that last known position,
+ *             so candidate count never widens back from 1 to 2.
+ */
+public class GradientSolver {
+
+    private static final double TOLERANCE      = 4.0;  // max allowed XZ residual
+    private static final double MIN_MOVE       = 1.5;  // min XZ displacement between readings
+    private static final int    REFINE_ITERS   = 10;   // sphere projection iterations
+    private static final double CONVERGE_DIST  = 3.0;  // auto-merge if within this many blocks
+    private static final double GRADIENT_AGREE = 0.35; // max cosθ error (dual-candidate discrimination only)
+    private static final int    MAX_READINGS   = 16;   // sliding window
+    private static final double SWITCH_SLACK   = 2.0;  // treasure-switch detection tolerance (blocks)
+
+    private final List<double[]> readings   = new ArrayList<>();  // {px, py, pz, d}
+    private final List<double[]> candidates = new ArrayList<>();  // {cx, cz}
+
+    private int      dualDisagreeCount = 0;
+    private int      dualDisagreeIdx   = -1; // -1=none, 0=A losing, 1=B losing
+    private double   lastX = Double.NaN, lastZ = Double.NaN;
+    private double[] lastSingleCandidate = null;
+
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    public synchronized boolean addReading(double px, double py, double pz, double d) {
+        if (!Double.isNaN(lastX)) {
+            double dx = px - lastX, dz = pz - lastZ;
+            double moveLenSq = dx * dx + dz * dz;
+            if (moveLenSq < MIN_MOVE * MIN_MOVE) return false;
+
+            // Treasure-switch detection: |Δd| > |ΔPos_3D| is geometrically impossible for a
+            // fixed treasure.  Use 3D movement so Y-axis mining doesn't cause false triggers.
+            if (!readings.isEmpty()) {
+                double[] lastR    = readings.get(readings.size() - 1);
+                double distChange = Math.abs(d - lastR[3]);
+                double dx3 = px - lastR[0], dy3 = py - lastR[1], dz3 = pz - lastR[2];
+                double move3D = Math.sqrt(dx3*dx3 + dy3*dy3 + dz3*dz3);
+                if (distChange > move3D + SWITCH_SLACK) {
+                    readings.clear();
+                    candidates.clear();
+                    dualDisagreeCount = 0;
+                    dualDisagreeIdx   = -1;
+                    lastSingleCandidate = null;
+                }
+            }
+        }
+        lastX = px; lastZ = pz;
+        if (readings.size() >= MAX_READINGS) readings.remove(0);
+        readings.add(new double[]{px, py, pz, d});
+        if (readings.size() >= 2) recompute();
+        return true;
+    }
+
+    public synchronized List<BlockPos> getCandidatePositions() {
+        if (candidates.isEmpty()) return Collections.emptyList();
+        double avgY = avgPlayerY();
+        List<BlockPos> result = new ArrayList<>();
+        for (double[] c : candidates)
+            result.add(new BlockPos((int) Math.floor(c[0]), (int) Math.floor(avgY), (int) Math.floor(c[1])));
+        return result;
+    }
+
+    public synchronized int getCandidateCount() { return candidates.size(); }
+    public synchronized int getReadingCount()   { return readings.size(); }
+
+    public synchronized void reset() {
+        readings.clear();
+        candidates.clear();
+        dualDisagreeCount = 0;
+        dualDisagreeIdx   = -1;
+        lastX = lastZ = Double.NaN;
+        lastSingleCandidate = null;
+    }
+
+    // ── Solver ────────────────────────────────────────────────────────────────
+
+    private void recompute() {
+        int n = readings.size();
+
+        if (!candidates.isEmpty()) {
+
+            // Single candidate — never drop it, never regenerate, just refine.
+            // Sphere projection converges the position naturally; consistency checks
+            // near the treasure are unreliable and cause the 1→2 regression.
+            if (candidates.size() == 1) {
+                double[] ref = refineWithSpheres(candidates.get(0)[0], candidates.get(0)[1]);
+                lastSingleCandidate = new double[]{ref[0], ref[1]};
+                candidates.set(0, ref);
+                return;
+            }
+
+            // 2 candidates — try to narrow to 1 via consistency + gradient.
+            List<double[]> reRefined = new ArrayList<>();
+            for (double[] c : candidates) {
+                double[] ref = refineWithSpheres(c[0], c[1]);
+                if (consistentEnough(ref)) reRefined.add(ref);
+            }
+
+            if (!reRefined.isEmpty()) {
+                List<double[]> merged = tryMerge(reRefined);
+
+                if (merged.size() == 2 && n >= 3) {
+                    boolean aDisagrees = gradientDisagrees(merged.get(0), n);
+                    boolean bDisagrees = gradientDisagrees(merged.get(1), n);
+                    if (aDisagrees && !bDisagrees) {
+                        if (dualDisagreeIdx == 0) dualDisagreeCount++;
+                        else { dualDisagreeIdx = 0; dualDisagreeCount = 1; }
+                    } else if (bDisagrees && !aDisagrees) {
+                        if (dualDisagreeIdx == 1) dualDisagreeCount++;
+                        else { dualDisagreeIdx = 1; dualDisagreeCount = 1; }
+                    } else {
+                        dualDisagreeIdx = -1; dualDisagreeCount = 0;
+                    }
+                    if (dualDisagreeCount >= 2) {
+                        double[] kept = (dualDisagreeIdx == 0) ? merged.get(1) : merged.get(0);
+                        merged = Collections.singletonList(kept);
+                        lastSingleCandidate = new double[]{kept[0], kept[1]};
+                        dualDisagreeIdx = -1; dualDisagreeCount = 0;
+                    }
+                } else {
+                    dualDisagreeIdx = -1; dualDisagreeCount = 0;
+                }
+                candidates.clear();
+                candidates.addAll(merged);
+                return;
+            }
+
+            candidates.clear();
+            dualDisagreeCount = 0;
+            dualDisagreeIdx   = -1;
+        }
+
+        // No candidates — generate from latest pair.
+        List<double[]> newCands = generateFromPair(readings.get(n - 2), readings.get(n - 1));
+        if (newCands.isEmpty()) return;
+
+        List<double[]> result = new ArrayList<>();
+        for (double[] c : newCands) {
+            double[] ref = refineWithSpheres(c[0], c[1]);
+            if (consistentWithMost(ref)) result.add(ref);
+        }
+
+        // Once locked to 1, always regenerate to exactly 1 — pick closest to last known position.
+        if (lastSingleCandidate != null && result.size() > 1) {
+            double[] best = result.get(0);
+            double bestDsq = xzDistSq(best, lastSingleCandidate);
+            for (double[] r : result) {
+                double dsq = xzDistSq(r, lastSingleCandidate);
+                if (dsq < bestDsq) { bestDsq = dsq; best = r; }
+            }
+            result = Collections.singletonList(best);
+        }
+
+        if (!result.isEmpty()) {
+            candidates.clear();
+            candidates.addAll(tryMerge(result));
+        }
+    }
+
+    // ── Gradient validation ───────────────────────────────────────────────────
+
+    /**
+     * Returns true if the measured gradient disagrees with the direction to candidate c.
+     *
+     *   cosθ_expected = dot(direction_to_c, movement) / |movement|
+     *   cosθ_actual   = -Δd / |ΔP|   (gradient formula: ∂d/∂û = -cosθ)
+     *
+     * A correct candidate should satisfy |cosθ_expected - cosθ_actual| < GRADIENT_AGREE.
+     */
+    private boolean gradientDisagrees(double[] c, int n) {
+        double[] r1 = readings.get(n - 2);
+        double[] r2 = readings.get(n - 1);
+
+        double dxMove = r2[0] - r1[0], dzMove = r2[2] - r1[2];
+        double moveLen = Math.sqrt(dxMove * dxMove + dzMove * dzMove);
+        if (moveLen < MIN_MOVE) return false;
+
+        double dxToC = c[0] - r1[0], dzToC = c[1] - r1[2];
+        double distToC = Math.sqrt(dxToC * dxToC + dzToC * dzToC);
+        if (distToC < 2.0) return false;
+
+        double cosExpected = (dxMove * dxToC + dzMove * dzToC) / (moveLen * distToC);
+        double cosActual   = Math.max(-1.0, Math.min(1.0, -(r2[3] - r1[3]) / moveLen));
+
+        return Math.abs(cosExpected - cosActual) > GRADIENT_AGREE;
+    }
+
+    // ── Sphere refinement ─────────────────────────────────────────────────────
+
+    /**
+     * Projects candidate (cx, cz) onto each reading's XZ circle and averages.
+     * Repeat for REFINE_ITERS — converges toward the true intersection.
+     */
+    private double[] refineWithSpheres(double cx, double cz) {
+        double avgY = avgPlayerY();
+        for (int iter = 0; iter < REFINE_ITERS; iter++) {
+            double sumX = 0, sumZ = 0;
+            int cnt = 0;
+            for (double[] r : readings) {
+                double dx = cx - r[0], dz = cz - r[2];
+                double xzDist = Math.sqrt(dx * dx + dz * dz);
+                if (xzDist < 0.5) continue;
+                double dY  = avgY - r[1];
+                double xzR = Math.sqrt(Math.max(1.0, r[3] * r[3] - dY * dY));
+                sumX += r[0] + (dx / xzDist) * xzR;
+                sumZ += r[2] + (dz / xzDist) * xzR;
+                cnt++;
+            }
+            if (cnt == 0) break;
+            cx = sumX / cnt;
+            cz = sumZ / cnt;
+        }
+        return new double[]{cx, cz};
+    }
+
+    // ── Gradient candidate generation ─────────────────────────────────────────
+
+    private static List<double[]> generateFromPair(double[] r1, double[] r2) {
+        double dx = r2[0] - r1[0], dz = r2[2] - r1[2];
+        double moveLen = Math.sqrt(dx * dx + dz * dz);
+        if (moveLen < 1e-6) return Collections.emptyList();
+
+        double dd = r2[3] - r1[3];
+        // |Δd| > moveLen is geometrically impossible for a fixed treasure — skip
+        if (Math.abs(dd) >= moveLen) return Collections.emptyList();
+
+        double cosTheta = Math.max(-1.0, Math.min(1.0, -dd / moveLen));
+        double theta    = Math.acos(cosTheta);
+        double bearing  = Math.atan2(dz, dx);
+        double d1       = r1[3];
+
+        List<double[]> result = new ArrayList<>(2);
+        result.add(new double[]{r1[0] + d1 * Math.cos(bearing + theta),
+                                r1[2] + d1 * Math.sin(bearing + theta)});
+        result.add(new double[]{r1[0] + d1 * Math.cos(bearing - theta),
+                                r1[2] + d1 * Math.sin(bearing - theta)});
+        return result;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private List<double[]> tryMerge(List<double[]> cands) {
+        if (cands.size() < 2) return cands;
+        double dx = cands.get(0)[0] - cands.get(1)[0];
+        double dz = cands.get(0)[1] - cands.get(1)[1];
+        if (dx * dx + dz * dz <= CONVERGE_DIST * CONVERGE_DIST) {
+            return Collections.singletonList(new double[]{
+                (cands.get(0)[0] + cands.get(1)[0]) / 2,
+                (cands.get(0)[1] + cands.get(1)[1]) / 2
+            });
+        }
+        return cands;
+    }
+
+    private boolean consistent(double[] c, double[] r) {
+        double dx = c[0] - r[0], dz = c[1] - r[2];
+        double xzDist = Math.sqrt(dx * dx + dz * dz);
+        double dY  = avgPlayerY() - r[1];
+        double xzR = Math.sqrt(Math.max(1.0, r[3] * r[3] - dY * dY));
+        return Math.abs(xzDist - xzR) <= TOLERANCE;
+    }
+
+    /** Strict: used for newly generated candidates — allows at most 1 inconsistent reading. */
+    private boolean consistentWithMost(double[] c) {
+        int ok = 0;
+        for (double[] r : readings) if (consistent(c, r)) ok++;
+        return ok >= readings.size() - 1;
+    }
+
+    /** Lenient: used when re-checking existing candidates — allows up to 25% noisy readings.
+     *  Prevents a good candidate from being dropped due to 2–3 slightly off readings. */
+    private boolean consistentEnough(double[] c) {
+        int ok = 0;
+        for (double[] r : readings) if (consistent(c, r)) ok++;
+        int maxFailures = Math.max(1, readings.size() / 4);
+        return ok >= readings.size() - maxFailures;
+    }
+
+    private static double xzDistSq(double[] a, double[] b) {
+        double dx = a[0] - b[0], dz = a[1] - b[1];
+        return dx * dx + dz * dz;
+    }
+
+    private double avgPlayerY() {
+        if (readings.isEmpty()) return 64;
+        double s = 0;
+        for (double[] r : readings) s += r[1];
+        return s / readings.size();
+    }
+}

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/TreasureTriangulator.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/mining/crystalhollows/treasure/TreasureTriangulator.java
@@ -11,10 +11,10 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class TreasureTriangulator {
 
     // ---------- Adjustable params ----------
-    private final double epsilon = 4.0;
+    private final double epsilon = 1.0; // metal detector reports to 1 decimal → true error ≤ 0.5 blocks
     private final int maxSamples = 24;
     private final int minSamples = 4;
-    private final double minPlayerDelta = 0.9; // bocks
+    private final double minPlayerDelta = 0.9; // blocks
     private final long estimateCooldownMs = 250; // 4hz
     private final double pruneK = 2.5;
 

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/BlazeAttunements.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/BlazeAttunements.java
@@ -8,7 +8,6 @@ import com.nef.notenoughfakepixel.serverdata.SkyblockData;
 import com.nef.notenoughfakepixel.utils.EntityHighlightUtils;
 import com.nef.notenoughfakepixel.utils.MapUtils;
 import com.nef.notenoughfakepixel.utils.OutlineUtils;
-import lombok.Getter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -21,27 +20,26 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import java.awt.*;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @RegisterEvents
 public class BlazeAttunements {
-    @Getter
-    public final Set<EntityLivingBase> blazeEntity = new HashSet<>();
+    public static final Map<EntityLivingBase, String> blazeEntity = new HashMap<>();
     private long lastUpdateTime = 0;
 
     @SubscribeEvent
     public void onRenderEntity(RenderLivingEvent.Pre<EntityLivingBase> event) {
-        if (!Config.feature.slayer.slayerBlazeAttunements) return;
+        if (!Config.feature.slayer.slayerBlazeAttunementOutline && !Config.feature.slayer.slayerBlazeAttunementFill) return;
         long currentTime = System.currentTimeMillis();
         if (currentTime - lastUpdateTime > 20) {
             blazeEntity.clear();
             lastUpdateTime = currentTime;
         }
+
         Minecraft mc = Minecraft.getMinecraft();
         if (mc.theWorld == null || mc.thePlayer == null) return;
         if (!SkyblockData.getCurrentGamemode().isSkyblock() || !SkyblockData.getCurrentLocation().isCrimson()) return;
@@ -76,7 +74,7 @@ public class BlazeAttunements {
                         }
 
                         if (allowed) {
-                            blazeEntity.add(entity);
+                            blazeEntity.put(entity, attunement);
                             return;
                         }
                     }
@@ -87,32 +85,18 @@ public class BlazeAttunements {
 
     @SubscribeEvent(priority = EventPriority.HIGH)
     public void onRenderEntityModel(RenderEntityModelEvent event) {
-        if (!Config.feature.slayer.slayerBlazeAttunements) return;
+        if (!Config.feature.slayer.slayerBlazeAttunementOutline) return;
         if (!SkyblockData.getCurrentGamemode().isSkyblock() || !SkyblockData.getCurrentLocation().isCrimson()) return;
 
         EntityLivingBase entity = event.getEntity();
-        if (entity == null || !blazeEntity.contains(entity)) return;
+        String attunement = blazeEntity.get(entity);
+        if (attunement == null) return;
 
-        List<Entity> armorStands = Minecraft.getMinecraft().theWorld.getEntitiesWithinAABB(
-                EntityArmorStand.class,
-                entity.getEntityBoundingBox().offset(0, 2.0, 0).expand(1.0, 1.0, 1.0)
-        );
-
-        for (Entity armorStand : armorStands) {
-            if (armorStand instanceof EntityArmorStand) {
-                String displayName = armorStand.getDisplayName().getUnformattedText();
-                Matcher matcher = COLOR_PATTERN.matcher(displayName);
-                if (matcher.find()) {
-                    String attunement = matcher.group().toUpperCase();
-                    Color color = new Color(getColorForAttunement(attunement));
-                    if (Configuration.isPojav()) {
-                        EntityHighlightUtils.renderEntityOutline(event, color);
-                    } else {
-                        OutlineUtils.outlineEntity(event, 6.0f, color, true);
-                    }
-                    return;
-                }
-            }
+        Color color = new Color(getColorForAttunement(attunement));
+        if (Configuration.isPojav()) {
+            EntityHighlightUtils.renderEntityOutline(event, color);
+        } else {
+            OutlineUtils.outlineEntity(event, 6.0f, color, true);
         }
     }
 

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/HellionShieldFilter.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/HellionShieldFilter.java
@@ -1,0 +1,23 @@
+package com.nef.notenoughfakepixel.features.skyblock.slayers;
+
+import com.nef.notenoughfakepixel.config.gui.Config;
+import com.nef.notenoughfakepixel.env.registers.RegisterEvents;
+import com.nef.notenoughfakepixel.serverdata.SkyblockData;
+import net.minecraftforge.client.event.ClientChatReceivedEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+@RegisterEvents
+public class HellionShieldFilter {
+
+    @SubscribeEvent
+    public void onChat(ClientChatReceivedEvent event) {
+        if (!Config.feature.slayer.slayerHellionShieldFilter) return;
+        if (!SkyblockData.getCurrentLocation().isCrimson()) return;
+
+        String msg = event.message.getUnformattedText();
+        if (msg.contains("Your hit was reduced by Hellion Shield!")
+                || msg.contains("attunement on your dagger!")) {
+            event.setCanceled(true);
+        }
+    }
+}

--- a/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/SlayerHealthDisplay.java
+++ b/src/main/java/com/nef/notenoughfakepixel/features/skyblock/slayers/SlayerHealthDisplay.java
@@ -4,30 +4,47 @@ import com.nef.notenoughfakepixel.config.gui.Config;
 import com.nef.notenoughfakepixel.config.gui.core.config.Position;
 import com.nef.notenoughfakepixel.env.registers.RegisterEvents;
 import com.nef.notenoughfakepixel.serverdata.SkyblockData;
-import com.nef.notenoughfakepixel.utils.ScoreboardUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityArmorStand;
+import net.minecraft.entity.monster.EntityPigZombie;
+import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.lwjgl.opengl.GL11;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
 
 @RegisterEvents
 public class SlayerHealthDisplay {
     private final Minecraft mc = Minecraft.getMinecraft();
     private String displayText = "";
     private boolean isBoss = false;
-    private final Position position; // Added position field
-
+    private final Position position;
     private int ticks = 0;
 
+    private boolean isDemonlordFight = false;
+    private final List<MinionInfo> minionInfos = new ArrayList<>();
+
     public SlayerHealthDisplay() {
-        this.position = Config.feature.slayer.slayerBossHPPos; // Initialize position
+        this.position = Config.feature.slayer.slayerBossHPPos;
+    }
+
+    private static class MinionInfo {
+        final String attunement;
+        final String hp;
+        final Boolean attackable; // null = unknown
+
+        MinionInfo(String attunement, String hp, Boolean attackable) {
+            this.attunement = attunement;
+            this.hp = hp;
+            this.attackable = attackable;
+        }
     }
 
     public static final String[] SLAYER_BOSSES = {
@@ -41,74 +58,170 @@ public class SlayerHealthDisplay {
 
     @SubscribeEvent
     public void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.side != net.minecraftforge.fml.relauncher.Side.CLIENT || mc.theWorld == null) {
-            return;
-        }
+        if (event.side != net.minecraftforge.fml.relauncher.Side.CLIENT || mc.theWorld == null) return;
 
         ticks++;
         if (ticks % 10 != 0) return;
 
-        if (Config.feature.slayer.slayerBossHP) {
-            List<String> sidebarLines = ScoreboardUtils.getScoreboardLines();
-            isBoss = SkyblockData.isBossActive();
+        if (!Config.feature.slayer.slayerBossHP) return;
 
-            // Find closest Slayer boss
-            if (isBoss && mc.thePlayer != null) {
-                List<Entity> entities = mc.theWorld.getLoadedEntityList();
-                Entity closestBoss = null;
-                double closestDistance = Double.MAX_VALUE;
-                String bossNameFound = "";
+        isBoss = SkyblockData.isBossActive();
+        if (!isBoss || mc.thePlayer == null) {
+            displayText = "";
+            isDemonlordFight = false;
+            minionInfos.clear();
+            return;
+        }
 
-                for (Entity entity : entities) {
-                    if (entity instanceof EntityArmorStand && entity.hasCustomName()) {
-                        String entityName = entity.getCustomNameTag();
-                        for (String bossName : SLAYER_BOSSES) {
-                            if (entityName.contains(bossName)) {
-                                double distance = mc.thePlayer.getDistanceToEntity(entity);
-                                if (distance < closestDistance) {
-                                    closestDistance = distance;
-                                    closestBoss = entity;
-                                    bossNameFound = entityName;
-                                }
-                                break;
-                            }
-                        }
+        List<Entity> entities = mc.theWorld.getLoadedEntityList();
+        Entity closestBoss = null;
+        double closestDistance = Double.MAX_VALUE;
+        String bossNameFound = "";
+
+        for (Entity entity : entities) {
+            if (!(entity instanceof EntityArmorStand) || !entity.hasCustomName()) continue;
+            String entityName = entity.getCustomNameTag();
+            for (String bossName : SLAYER_BOSSES) {
+                if (entityName.contains(bossName)) {
+                    double distance = mc.thePlayer.getDistanceToEntity(entity);
+                    if (distance < closestDistance) {
+                        closestDistance = distance;
+                        closestBoss = entity;
+                        bossNameFound = entityName;
                     }
+                    break;
                 }
-                displayText = (closestBoss != null) ? bossNameFound : "";
-            } else {
-                displayText = "";
             }
+        }
+
+        if (closestBoss != null) {
+            if (bossNameFound.contains("Inferno Demonlord")) {
+                isDemonlordFight = true;
+                minionInfos.clear();
+                String attunement = findAttunementNear(entities, closestBoss, 4.0);
+                displayText = bossNameFound + (attunement.isEmpty() ? "" : " " + colorCode(attunement) + "[" + attunement + "]§r");
+            } else {
+                isDemonlordFight = false;
+                minionInfos.clear();
+                displayText = bossNameFound;
+            }
+        } else if (isDemonlordFight) {
+            // Boss armor stand gone — minion phase
+            displayText = "";
+            updateMinionInfos(entities);
+        } else {
+            displayText = "";
+            minionInfos.clear();
+        }
+    }
+
+    private String findAttunementNear(List<Entity> entities, Entity reference, double maxDist) {
+        double maxDistSq = maxDist * maxDist;
+        for (Entity e : entities) {
+            if (!(e instanceof EntityArmorStand) || e == reference || !e.hasCustomName()) continue;
+            if (reference.getDistanceSqToEntity(e) > maxDistSq) continue;
+            String name = ((EntityArmorStand) e).getDisplayName().getUnformattedText();
+            Matcher m = BlazeAttunements.COLOR_PATTERN.matcher(name);
+            if (m.find()) return m.group().toUpperCase();
+        }
+        return "";
+    }
+
+    private void updateMinionInfos(List<Entity> entities) {
+        minionInfos.clear();
+
+        for (Entity e : entities) {
+            boolean isWither = e instanceof EntitySkeleton && ((EntitySkeleton) e).getSkeletonType() == 1;
+            boolean isPigZombie = e instanceof EntityPigZombie;
+            if ((!isWither && !isPigZombie) || mc.thePlayer.getDistanceSqToEntity(e) > 50) continue;
+
+            net.minecraft.entity.EntityLivingBase minion = (net.minecraft.entity.EntityLivingBase) e;
+            String attunement = BlazeAttunements.blazeEntity.get(minion);
+            boolean attackable = attunement != null;
+
+            // Find HP from the nearest armor stand with a health bar
+            String hp = "";
+            for (Entity stand : entities) {
+                if (!(stand instanceof EntityArmorStand)) continue;
+                if (stand.getDistanceSqToEntity(minion) > 25.0) continue;
+                String name = stand.getDisplayName().getUnformattedText();
+                if (name.contains("❤")) { hp = name; break; }
+            }
+
+            if (attunement == null && hp.isEmpty()) continue;
+            minionInfos.add(new MinionInfo(attunement != null ? attunement : "", hp, attackable));
+        }
+    }
+
+    private String colorCode(String attunement) {
+        switch (attunement) {
+            case "SPIRIT": return "§f";
+            case "ASHEN": return "§8";
+            case "CRYSTAL": return "§b";
+            case "AURIC": return "§e";
+            default: return "§r";
+        }
+    }
+
+    private int attunementColor(String attunement) {
+        switch (attunement) {
+            case "ASHEN": return 0x555555;
+            case "SPIRIT": return 0xFFFFFF;
+            case "CRYSTAL": return 0x55FFFF;
+            case "AURIC": return 0xFFFF55;
+            default: return 0xFF5555;
         }
     }
 
     @SubscribeEvent
     public void onRenderGameOverlay(RenderGameOverlayEvent event) {
-        if (event.type != RenderGameOverlayEvent.ElementType.ALL || displayText.isEmpty() || !isBoss) {
-            return;
-        }
+        if (event.type != RenderGameOverlayEvent.ElementType.ALL || !isBoss) return;
+
+        boolean showBoss = !displayText.isEmpty();
+        boolean showMinions = !minionInfos.isEmpty();
+        if (!showBoss && !showMinions) return;
 
         ScaledResolution resolution = event.resolution;
         FontRenderer fr = mc.fontRendererObj;
         float scale = 2.0F;
 
         GL11.glPushMatrix();
-
         GL11.glScalef(scale, scale, scale);
-        int textWidth = fr.getStringWidth(displayText);
-        int textHeight = fr.FONT_HEIGHT;
 
-        int x = position.getAbsX(resolution, textWidth) / (int) scale;
-        int y = position.getAbsY(resolution, textHeight) / (int) scale;
+        if (showBoss) {
+            int textWidth = fr.getStringWidth(displayText);
+            int x = position.getAbsX(resolution, textWidth) / (int) scale;
+            int y = position.getAbsY(resolution, fr.FONT_HEIGHT) / (int) scale;
+            fr.drawStringWithShadow(displayText, x, y, 0xFF5555);
+        } else {
+            int lineHeight = fr.FONT_HEIGHT + 2;
+            int totalHeight = lineHeight * minionInfos.size();
+            String firstLine = buildMinionLine(minionInfos.get(0));
+            int x = position.getAbsX(resolution, fr.getStringWidth(firstLine)) / (int) scale;
+            int baseY = position.getAbsY(resolution, totalHeight) / (int) scale;
 
-        fr.drawStringWithShadow(displayText, x, y, 0xFF5555);
+            for (int i = 0; i < minionInfos.size(); i++) {
+                MinionInfo info = minionInfos.get(i);
+                fr.drawStringWithShadow(buildMinionLine(info), x, baseY + i * lineHeight, attunementColor(info.attunement));
+            }
+        }
 
         GL11.glPopMatrix();
+    }
+
+    private String buildMinionLine(MinionInfo info) {
+        StringBuilder sb = new StringBuilder();
+        if (!info.attunement.isEmpty()) sb.append("[").append(info.attunement).append("] ");
+        sb.append(info.attackable ? "ATTACK" : "IMMUNE");
+        if (!info.hp.isEmpty()) sb.append(" ").append(info.hp);
+        return sb.toString();
     }
 
     @SubscribeEvent
     public void onWorldUnload(net.minecraftforge.event.world.WorldEvent.Unload event) {
         displayText = "";
         isBoss = false;
+        isDemonlordFight = false;
+        minionInfos.clear();
     }
 }

--- a/src/main/java/com/nef/notenoughfakepixel/mixin/MixinRendererLivingEntity.java
+++ b/src/main/java/com/nef/notenoughfakepixel/mixin/MixinRendererLivingEntity.java
@@ -16,7 +16,6 @@ import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.boss.EntityWither;
-import net.minecraft.entity.item.EntityArmorStand;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.MinecraftForge;
 import org.spongepowered.asm.mixin.Final;
@@ -30,9 +29,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.awt.*;
 import java.nio.FloatBuffer;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 
 import static org.lwjgl.opengl.GL11.glTexEnv;
 import static org.lwjgl.opengl.GL11.glTexEnvi;
@@ -54,15 +51,11 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> {
     private final Diana notEnoughFakepixel$diana = new Diana();
     private final LividDisplay notEnoughFakepixel$lividDisplay = new LividDisplay();
     private final SlayerMobsDisplay notEnoughFakepixel$slayerMobsDisplay = new SlayerMobsDisplay();
-    private final BlazeAttunements notEnoughFakepixel$blaze = new BlazeAttunements();
-
     private final Set<EntityLivingBase> notEnoughFakepixel$starredEntities = notEnoughFakepixel$starredMobDisplay.getCurrentEntities();
     private final Set<EntityLivingBase> notEnoughFakepixel$inqEntities = notEnoughFakepixel$diana.getCurrentEntities();
     private final Set<EntityLivingBase> notEnoughFakepixel$lividEntities = notEnoughFakepixel$lividDisplay.getLividEntity();
     private final Set<EntityLivingBase> notEnoughFakepixel$slayerEntities = notEnoughFakepixel$slayerMobsDisplay.getSlayerEntity();
     private final Set<EntityLivingBase> notEnoughFakepixel$slayerMiniEntities = notEnoughFakepixel$slayerMobsDisplay.getSlayerMiniEntity();
-    private final Set<EntityLivingBase> notEnoughFakepixel$blazeEntities = notEnoughFakepixel$blaze.getBlazeEntity();
-
     @Redirect(method = "renderName*", at = @At(value = "INVOKE", target =
             "Lnet/minecraft/entity/EntityLivingBase;getDisplayName()Lnet/minecraft/util/IChatComponent;"))
     public IChatComponent renderName_getDisplayName(EntityLivingBase entity) {
@@ -149,8 +142,8 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> {
             return true;
         }
 
-        // Blaze Attunements
-        if (notEnoughFakepixel$blazeEntities.contains(entity)) {
+        // Blaze Attunements fill
+        if (Config.feature.slayer.slayerBlazeAttunementFill && BlazeAttunements.blazeEntity.containsKey(entity)) {
             return true;
         }
 
@@ -185,23 +178,11 @@ public abstract class MixinRendererLivingEntity<T extends EntityLivingBase> {
 
         }
 
-        if (notEnoughFakepixel$blazeEntities.contains(entity)) {
-            List<Entity> armorStands = entity.worldObj.getEntitiesWithinAABB(
-                    EntityArmorStand.class,
-                    entity.getEntityBoundingBox().offset(0, 2.0, 0).expand(1.0, 1.0, 1.0)
-            );
-            for (Entity armorStand : armorStands) {
-                if (armorStand instanceof EntityArmorStand) {
-                    String displayName = armorStand.getDisplayName().getUnformattedText();
-                    Matcher matcher = BlazeAttunements.COLOR_PATTERN.matcher(displayName);
-                    if (matcher.find()) {
-                        String attunement = matcher.group().toUpperCase();
-                        int colorInt = BlazeAttunements.getColorForAttunement(attunement);
-                        if (colorInt != -1) {
-                            return new Color(colorInt);
-                        }
-                    }
-                }
+        if (Config.feature.slayer.slayerBlazeAttunementFill) {
+            String blazeAttunement = BlazeAttunements.blazeEntity.get(entity);
+            if (blazeAttunement != null) {
+                int colorInt = BlazeAttunements.getColorForAttunement(blazeAttunement);
+                if (colorInt != -1) return new Color(colorInt);
             }
         }
 

--- a/src/main/java/com/nef/notenoughfakepixel/variables/Location.java
+++ b/src/main/java/com/nef/notenoughfakepixel/variables/Location.java
@@ -53,4 +53,8 @@ public enum Location {
         return this == THE_END;
     }
 
+    public boolean isCrystalHollows() {
+        return this == CRYSTAL_HOLLOWS;
+    }
+
 }


### PR DESCRIPTION
Did some changes and added some features here and there. 
All usefull promise. Enjoy :):

Add Crystal Hollows chest tracker, fishing slug mode, blaze attunement improvements, and misc fixes

   - Crystal Hollows: add ChestTracker (packet-based chest detection with GL wireframe overlay) and TrackedChest data class; add isCrystalHollows() helper to Location.java; add chestTracker toggle and
   chestTrackerClearKey keybind to Mining config
   - Fishing: add Slug Mode (suppress sound/overlay while waiting after lava entry); remove Flash enchant velocity-packet detection which caused false-positive alerts; fix GreatCatchNotifier to only handle
   type-1 entity status packets
   - Metal detector: remove Slow & Steady SphereSolver path entirely, keep only the GradientSolver (Fast & Janky) mode; remove mode-select dropdown from Mining config
   - Blaze attunements: refactor blazeEntity from a Set to a public static Map<EntityLivingBase, String> so attunement data is shared without re-scanning armor stands; split config into separate outline and
    fill toggles; update MixinRendererLivingEntity and SlayerHealthDisplay to use the static map
   - Slayer config: restructure Inferno Demonlord settings under their own accordion; add HellionShieldFilter to suppress Hellion Shield / wrong-attunement spam messages